### PR TITLE
Update Python age

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <h1>Python is dead.</h1>
         <p>
             After many years of being on life support, Python has finally been
-            pronounced dead at the age of 23. Python leaves behind it's younger
+            pronounced dead at the age of 29. Python leaves behind it's younger
             sibling Nim. Of course, they'll be dead soon too,
             because no one can afford to be Nim programmers.
         </p>


### PR DESCRIPTION
Updates the current Python age to 29. Prior age was left in from the rubyisdead.science fork. 